### PR TITLE
making redis-connector.service a simple service

### DIFF
--- a/vbng-control/bng-utils.sls
+++ b/vbng-control/bng-utils.sls
@@ -27,7 +27,8 @@ bng_utils_config:
     - mode: 644
     - makedirs: True
     - template: jinja
-    - replace: True
+    - makedirs: True
+    - replace: False
     - contents_pillar: bng_utils:config
 
 bng_utils_service:
@@ -38,7 +39,7 @@ bng_utils_service:
     - group: root
     - mode: 644
     - makedirs: True
-    - replace: True
+    - replace: False
   cmd.run:
     - name: systemctl daemon-reload
     - onchanges:

--- a/vbng-control/files/redis-connector.service
+++ b/vbng-control/files/redis-connector.service
@@ -4,7 +4,7 @@ After=network.target
 Requires=network.target
 
 [Service]
-Type=oneshot
+Type=simple
 EnvironmentFile=-/etc/default/redis-connector
 ExecStart=/opt/bng-utils/dpdk-ip-pipeline-cli.py $OPTIONS
 


### PR DESCRIPTION
* changed redis-connector.service type from "oneshot" to "simple"
* do not overwrite /etc/default/redis-connector if the file already exists
* do not overwrite /etc/systemd/system/redis-connector.service if the file already exists